### PR TITLE
Add pytest suite with SSA examples

### DIFF
--- a/py_rssa/tests/test_forecast.py
+++ b/py_rssa/tests/test_forecast.py
@@ -1,0 +1,11 @@
+import pytest
+
+np = pytest.importorskip('numpy')
+py_rssa = pytest.importorskip('py_rssa')
+
+
+def test_basic_forecast():
+    data = np.sin(np.linspace(0, 2 * np.pi, 60))
+    ss = py_rssa.ssa(data, L=20)
+    fc = py_rssa.forecast(ss, groups=[1], steps=10)
+    assert fc.shape[0] == data.shape[0] + 10

--- a/py_rssa/tests/test_gap_fill.py
+++ b/py_rssa/tests/test_gap_fill.py
@@ -1,0 +1,12 @@
+import pytest
+
+np = pytest.importorskip('numpy')
+py_rssa = pytest.importorskip('py_rssa')
+
+
+def test_gap_fill():
+    data = np.sin(np.linspace(0, 2 * np.pi, 60))
+    data[10] = np.nan
+    ss = py_rssa.ssa(data, L=20)
+    filled = py_rssa.gapfill(ss, groups=[1])
+    assert not np.isnan(filled[10])

--- a/py_rssa/tests/test_mssa.py
+++ b/py_rssa/tests/test_mssa.py
@@ -1,0 +1,14 @@
+import pytest
+
+np = pytest.importorskip('numpy')
+py_rssa = pytest.importorskip('py_rssa')
+
+
+def test_mssa_reconstruction():
+    ts1 = np.sin(np.linspace(0, 4 * np.pi, 100))
+    ts2 = np.cos(np.linspace(0, 4 * np.pi, 100))
+    ss = py_rssa.mssa([ts1, ts2], L=30)
+    rec = py_rssa.reconstruct(ss, groups=[1, 2])
+    assert len(rec) == 2
+    assert rec[0].shape == ts1.shape
+    assert rec[1].shape == ts2.shape


### PR DESCRIPTION
## Summary
- set up `py_rssa/tests`
- add forecast, gap filling and multivariate SSA tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685edc9bd0088330b9829d1937ba55dd