### PR TITLE
Add Python Cadzow denoising

### DIFF
--- a/py_rssa/py_rssa/__init__.py
+++ b/py_rssa/py_rssa/__init__.py
@@ -2,6 +2,7 @@
 
 from .ssa import SSA, ssa
 from .hankel import hankel_mv
+from .cadzow import cadzow
 from . import datasets
 
-__all__ = ["SSA", "ssa", "datasets", "hankel_mv"]
+__all__ = ["SSA", "ssa", "datasets", "hankel_mv", "cadzow"]

--- a/py_rssa/py_rssa/cadzow.py
+++ b/py_rssa/py_rssa/cadzow.py
@@ -1,0 +1,89 @@
+# Utilities and Cadzow iterations for SSA denoising
+# Ported from R/cadzow.R
+
+import numpy as np
+
+from .ssa import SSA, hankel_weights
+
+
+def _extend_series(x, alpha):
+    """Scale series or list of series by ``alpha``."""
+    if isinstance(x, (list, tuple)):
+        return [_extend_series(v, alpha) for v in x]
+    return alpha * np.asarray(x)
+
+
+def _series_dist(f1, f2, norm_func, mask=None):
+    """Distance between two series according to ``norm_func``."""
+    a = np.asarray(f1).ravel()
+    b = np.asarray(f2).ravel()
+    if mask is not None:
+        mask = np.asarray(mask, dtype=bool)
+        a = a[mask]
+        b = b[mask]
+    return norm_func(a - b)
+
+
+def _series_winnerprod(f1, f2, weights=1):
+    """Weighted inner product of two series."""
+    a = np.asarray(f1).ravel()
+    b = np.asarray(f2).ravel()
+    w = np.asarray(weights)
+    if w.ndim == 0:
+        w = np.full_like(a, float(w))
+    mask = w > 0
+    return float(np.sum(w[mask] * a[mask] * b[mask]))
+
+
+def cadzow(
+    ssa_obj,
+    rank,
+    *,
+    correct=True,
+    tol=1e-6,
+    maxiter=0,
+    norm=lambda x: np.max(np.abs(x)),
+    trace=False,
+):
+    """Perform Cadzow denoising on an :class:`SSA` object.
+
+    Parameters
+    ----------
+    ssa_obj : :class:`SSA`
+        Input SSA decomposition.
+    rank : int
+        Desired rank of the approximation.
+    correct : bool, optional
+        Whether to perform final correction as in the R implementation.
+    tol : float, optional
+        Convergence tolerance for the iterations.
+    maxiter : int, optional
+        Maximum number of iterations. ``0`` means no limit.
+    norm : callable, optional
+        Norm function used to check convergence.
+    trace : bool, optional
+        If ``True``, progress is printed during iterations.
+    """
+    weights = hankel_weights(ssa_obj.L, ssa_obj.K)
+    mask = weights > 0
+
+    F = ssa_obj.reconstruct(range(rank))
+
+    it = 0
+    while True:
+        tmp = SSA(F, L=ssa_obj.L)
+        rF = tmp.reconstruct(range(rank))
+        it += 1
+        dist = _series_dist(F, rF, norm, mask)
+        if (maxiter > 0 and it >= maxiter) or dist < tol:
+            break
+        if trace:
+            print(f"Iteration: {it}, distance: {dist}")
+        F = rF
+
+    if correct:
+        alpha = _series_winnerprod(ssa_obj.x, F, weights) / _series_winnerprod(
+            F, F, weights
+        )
+        F = _extend_series(F, alpha)
+    return F

--- a/py_rssa/tests/test_cadzow.py
+++ b/py_rssa/tests/test_cadzow.py
@@ -1,0 +1,11 @@
+import pytest
+
+np = pytest.importorskip("numpy")
+py_rssa = pytest.importorskip("py_rssa")
+
+
+def test_cadzow_basic():
+    x = np.sin(np.linspace(0, 2 * np.pi, 60)) + 0.1 * np.random.randn(60)
+    s = py_rssa.SSA(x, L=30)
+    res = py_rssa.cadzow(s, rank=1, maxiter=2)
+    assert res.shape == x.shape


### PR DESCRIPTION
## Summary
- port basic Cadzow routines from `R/cadzow.R` to Python
- export `cadzow` in `py_rssa`
- test Cadzow on a simple sine wave

## Testing
- `pytest -q py_rssa/tests/test_cadzow.py` *(fails: numpy missing)*

------
https://chatgpt.com/codex/tasks/task_e_685f07d2513c83308de4f65946f8c311