### PR TITLE
Add complex Hankel helpers

### DIFF
--- a/py_rssa/py_rssa/__init__.py
+++ b/py_rssa/py_rssa/__init__.py
@@ -1,7 +1,9 @@
 """Lightweight Python implementation of selected rssa routines."""
 
-from .ssa import SSA, ssa
+from .ssa import SSA, ssa, hankel_weights
 from .hankel import hankel_mv
+from .chankel import chankel_mv, chankelize, chankelize_multi
 from . import datasets
 
-__all__ = ["SSA", "ssa", "datasets", "hankel_mv"]
+__all__ = ["SSA", "ssa", "datasets", "hankel_mv", "chankel_mv",
+           "chankelize", "chankelize_multi", "hankel_weights"]

--- a/py_rssa/py_rssa/chankel.py
+++ b/py_rssa/py_rssa/chankel.py
@@ -1,0 +1,59 @@
+"""Complex Hankel matrix helpers."""
+
+import numpy as np
+
+from .ssa import hankel_weights
+
+
+def _chankel_mv(F, v):
+    """Internal FFT-based complex Hankel multiplication."""
+    N = len(F)
+    K = len(v)
+    L = N - K + 1
+    if L <= 0:
+        raise ValueError("Invalid dimensions")
+    M = 1 << ((N + K - 1).bit_length())
+    F_freq = np.fft.fft(F, n=M)
+    V_freq = np.fft.fft(np.concatenate([v[::-1], np.zeros(M - K, dtype=complex)]), n=M)
+    res = np.fft.ifft(F_freq * V_freq, n=M)
+    return res[K-1:K-1+L]
+
+
+def chankel_mv(F, v):
+    """Multiply complex Hankel matrix built from sequence ``F`` with vector ``v``."""
+    F = np.asarray(F, dtype=complex)
+    v = np.asarray(v, dtype=complex)
+    return _chankel_mv(F, v)
+
+
+def chankelize(U, V):
+    """Hankelize a single pair of complex vectors ``U`` and ``V``."""
+    U = np.asarray(U, dtype=complex)
+    V = np.asarray(V, dtype=complex)
+    L = len(U)
+    K = len(V)
+    conv = np.convolve(U, V)
+    w = hankel_weights(L, K)
+    return conv / w
+
+
+def chankelize_multi(U, V):
+    """Hankelize multiple pairs of complex vectors.
+
+    ``U`` and ``V`` should be 2-D arrays with shapes ``(L, r)`` and ``(K, r)``
+    respectively. The result is a complex vector of length ``L + K - 1``.
+    """
+    U = np.asarray(U, dtype=complex)
+    V = np.asarray(V, dtype=complex)
+    if U.ndim != 2 or V.ndim != 2:
+        raise ValueError("U and V must be two-dimensional")
+    if U.shape[1] != V.shape[1]:
+        raise ValueError("U and V must have the same number of columns")
+    L, r = U.shape
+    K = V.shape[0]
+    res = np.zeros(L + K - 1, dtype=complex)
+    for i in range(r):
+        res += np.convolve(U[:, i], V[:, i])
+    w = hankel_weights(L, K)
+    return res / w
+

--- a/py_rssa/tests/test_chankel.py
+++ b/py_rssa/tests/test_chankel.py
@@ -1,0 +1,26 @@
+import pytest
+
+np = pytest.importorskip('numpy')
+py_rssa = pytest.importorskip('py_rssa')
+
+
+def test_chankel_mv():
+    F = np.array([1+2j, 3+4j, 5+6j, 7+8j])
+    v = np.array([2+1j, -1+0.5j])
+    res = py_rssa.chankel_mv(F, v)
+    L = len(F) - len(v) + 1
+    expected = np.array([
+        sum(F[i+j] * v[j] for j in range(len(v)))
+        for i in range(L)
+    ], dtype=complex)
+    assert np.allclose(res, expected)
+
+
+def test_chankelize():
+    U = np.array([1+1j, 2-1j])
+    V = np.array([3+2j, 4-2j, 5+0.5j])
+    res = py_rssa.chankelize(U, V)
+    weights = py_rssa.hankel_weights(len(U), len(V))
+    expected = np.convolve(U, V) / weights
+    assert np.allclose(res, expected)
+


### PR DESCRIPTION
## Summary
- add new ``chankel`` module for complex Hankel operations
- expose new helpers in package ``__init__``
- test complex Hankel multiplication and hankelization

## Testing
- `pytest -q` *(fails: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_685f07d55a788330a735db2108cecb97