### PR TITLE
Add matplotlib plotting helpers

### DIFF
--- a/py_rssa/py_rssa/__init__.py
+++ b/py_rssa/py_rssa/__init__.py
@@ -2,6 +2,23 @@
 
 from .ssa import SSA, ssa
 from .hankel import hankel_mv
+from .plot import (
+    plot,
+    plot_values,
+    plot_vectors,
+    plot_series,
+    plot_wcor,
+)
 from . import datasets
 
-__all__ = ["SSA", "ssa", "datasets", "hankel_mv"]
+__all__ = [
+    "SSA",
+    "ssa",
+    "datasets",
+    "hankel_mv",
+    "plot",
+    "plot_values",
+    "plot_vectors",
+    "plot_series",
+    "plot_wcor",
+]

--- a/py_rssa/py_rssa/plot.py
+++ b/py_rssa/py_rssa/plot.py
@@ -1,0 +1,99 @@
+# Helper plotting routines for the SSA class
+import numpy as np
+import matplotlib.pyplot as plt
+
+
+def plot_values(ssa_obj, numvalues=None, ax=None, **kwargs):
+    """Plot the singular values of ``ssa_obj``.
+
+    Parameters
+    ----------
+    ssa_obj : :class:`SSA`
+        Decomposed SSA object.
+    numvalues : int, optional
+        Number of singular values to plot.  By default all available
+        values are shown.
+    ax : matplotlib axes, optional
+        Axes to draw into.
+    **kwargs : dict
+        Additional keyword arguments passed to ``ax.plot``.
+    """
+    if numvalues is None:
+        numvalues = len(ssa_obj.s)
+    if ax is None:
+        ax = plt.gca()
+    x = np.arange(1, numvalues + 1)
+    y = ssa_obj.s[:numvalues]
+    ax.plot(x, y, marker="o", **kwargs)
+    ax.set_xlabel("Index")
+    ax.set_ylabel("norms")
+    ax.set_title("Component norms")
+    ax.set_yscale("log")
+    ax.grid(True)
+    return ax
+
+
+def _ensure_axes(n, axes=None):
+    if axes is None:
+        fig, axes = plt.subplots(n, 1, squeeze=False)
+        axes = axes.ravel()
+    return axes
+
+
+def plot_vectors(ssa_obj, indices=None, kind="eigen", axes=None, **kwargs):
+    """Plot eigen or factor vectors."""
+    if indices is None:
+        indices = list(range(min(len(ssa_obj.s), 10)))
+    axes = _ensure_axes(len(indices), axes)
+    V = ssa_obj.Vt.T
+    for ax, idx in zip(axes, indices):
+        vec = ssa_obj.U[:, idx] if kind == "eigen" else V[:, idx]
+        ax.plot(vec, **kwargs)
+        ax.axhline(0, color="gray", lw=0.5)
+        ax.set_ylabel(f"{kind[0].upper()}{idx+1}")
+    axes[-1].set_xlabel("Index")
+    axes[0].set_title("Eigenvectors" if kind == "eigen" else "Factor vectors")
+    return axes
+
+
+def plot_series(ssa_obj, groups=None, axes=None, **kwargs):
+    """Plot reconstructed series for given ``groups``."""
+    if groups is None:
+        groups = [[i] for i in range(min(len(ssa_obj.s), ssa_obj.U.shape[1]))]
+    series = [ssa_obj.reconstruct(g) for g in groups]
+    axes = _ensure_axes(len(series), axes)
+    for ax, s, g in zip(axes, series, groups):
+        ax.plot(s, **kwargs)
+        ax.set_ylabel(str(g))
+        ax.grid(True)
+    axes[-1].set_xlabel("Index")
+    axes[0].set_title("Reconstructed series")
+    return axes
+
+
+def plot_wcor(ssa_obj, groups=None, ax=None, **kwargs):
+    """Display weighted correlation matrix."""
+    if groups is None:
+        groups = [[i] for i in range(min(len(ssa_obj.s), ssa_obj.U.shape[1]))]
+    wc = np.abs(ssa_obj.wcor(groups))
+    if ax is None:
+        ax = plt.gca()
+    im = ax.imshow(wc, vmin=0.0, vmax=1.0, origin="lower", **kwargs)
+    ax.set_xlabel("Component")
+    ax.set_ylabel("Component")
+    ax.set_title("W-correlation matrix")
+    ax.figure.colorbar(im, ax=ax)
+    return ax
+
+
+def plot(ssa_obj, type="values", **kwargs):
+    """High level plot similar to ``plot.ssa`` in R."""
+    if type == "values":
+        return plot_values(ssa_obj, **kwargs)
+    if type == "vectors":
+        return plot_vectors(ssa_obj, **kwargs)
+    if type == "series":
+        return plot_series(ssa_obj, **kwargs)
+    if type == "wcor":
+        return plot_wcor(ssa_obj, **kwargs)
+    raise ValueError("Unsupported plot type")

--- a/py_rssa/tests/test_plot.py
+++ b/py_rssa/tests/test_plot.py
@@ -1,0 +1,23 @@
+import pytest
+
+np = pytest.importorskip("numpy")
+plt = pytest.importorskip("matplotlib.pyplot")
+
+from py_rssa import SSA, plot_values, plot_vectors, plot_series, plot_wcor
+
+
+def test_plot_helpers_smoke():
+    data = np.sin(np.linspace(0, 2 * np.pi, 60))
+    ss = SSA(data, L=20)
+
+    ax = plot_values(ss, numvalues=5)
+    plt.close(ax.figure)
+
+    axes = plot_vectors(ss, indices=[0, 1])
+    plt.close(axes[0].figure)
+
+    axes = plot_series(ss, groups=[[0], [1]])
+    plt.close(axes[0].figure)
+
+    ax = plot_wcor(ss, groups=[[0], [1]])
+    plt.close(ax.figure)


### PR DESCRIPTION
## Summary
- expose high-level plotting API
- implement matplotlib helpers for SSA plotting
- test helper functions with a smoke test

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_685f07e05f9483309d4e72cc1b73e393