### PR TITLE
Add weighted correlation utilities

### DIFF
--- a/py_rssa/README.md
+++ b/py_rssa/README.md
@@ -2,4 +2,4 @@
 
 This is a partial Python reimplementation of the `rssa` package. It now
 includes a pure Python Hankel helper and exposes basic ``ssa``,
-``reconstruct`` and ``wcor`` capabilities.
+``reconstruct``, ``wcor`` and ``wnorm`` capabilities.

--- a/py_rssa/docs/index.rst
+++ b/py_rssa/docs/index.rst
@@ -12,3 +12,4 @@ Usage example::
    s = SSA(x)
    recon = s.reconstruct([0])
    w = s.wcor()
+   n = wnorm(x)

--- a/py_rssa/py_rssa/__init__.py
+++ b/py_rssa/py_rssa/__init__.py
@@ -1,7 +1,7 @@
 """Lightweight Python implementation of selected rssa routines."""
 
-from .ssa import SSA, ssa
+from .ssa import SSA, ssa, wcor, wnorm
 from .hankel import hankel_mv
 from . import datasets
 
-__all__ = ["SSA", "ssa", "datasets", "hankel_mv"]
+__all__ = ["SSA", "ssa", "wcor", "wnorm", "datasets", "hankel_mv"]

--- a/py_rssa/tests/test_basic.py
+++ b/py_rssa/tests/test_basic.py
@@ -1,5 +1,5 @@
 import numpy as np
-from py_rssa import SSA
+from py_rssa import SSA, wcor, wnorm
 
 
 def test_reconstruct_identity():
@@ -14,3 +14,19 @@ def test_wcor_diagonal():
     s = SSA(x, L=10)
     w = s.wcor()
     assert np.allclose(np.diag(w), 1.0)
+
+
+def test_wcor_matrix_symmetry():
+    t = np.linspace(0, 2*np.pi, 20)
+    m = np.vstack((np.sin(t), np.cos(t))).T
+    w = wcor(m, L=10)
+    assert np.allclose(w, w.T)
+    assert np.allclose(np.diag(w), 1.0)
+
+
+def test_wnorm_basic():
+    x = np.arange(1, 6, dtype=float)
+    n = wnorm(x, L=3)
+    w = np.array([1, 2, 3, 2, 1], dtype=float)
+    expected = np.sqrt(np.sum(w * x**2))
+    assert np.allclose(n, expected)


### PR DESCRIPTION
## Summary
- expose new `wcor` and `wnorm` helpers in Python API
- use `wcor` in `SSA.wcor`
- document new helpers
- expand test suite

## Testing
- `pytest -q py_rssa/tests/test_basic.py` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_685f07e695b88330b5bafe1e46f5c83e