### PR TITLE
Add FFTW startup check for Python

### DIFF
--- a/py_rssa/py_rssa/__init__.py
+++ b/py_rssa/py_rssa/__init__.py
@@ -1,7 +1,24 @@
 """Lightweight Python implementation of selected rssa routines."""
 
+from __future__ import annotations
+
+import warnings
+
+try:  # pragma: no cover - optional dependency
+    import pyfftw  # type: ignore
+    HAVE_FFTW = True
+except Exception:  # pragma: no cover - pyfftw missing
+    HAVE_FFTW = False
+
+if not HAVE_FFTW:  # pragma: no cover - depends on environment
+    warnings.warn(
+        "\nWARNING: py_rssa was compiled without FFTW support.\n"
+        "The speed of the routines will be slower as well.",
+        RuntimeWarning,
+    )
+
 from .ssa import SSA, ssa
 from .hankel import hankel_mv
 from . import datasets
 
-__all__ = ["SSA", "ssa", "datasets", "hankel_mv"]
+__all__ = ["SSA", "ssa", "datasets", "hankel_mv", "HAVE_FFTW"]


### PR DESCRIPTION
## Summary
- replicate startup message logic from R/init.R.in in the Python package
- issue a warning when pyfftw isn't available

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_685f07e7f370833090aae92cab9ddc70