### PR TITLE
Add NDSSA and complex SSA

### DIFF
--- a/py_rssa/README.md
+++ b/py_rssa/README.md
@@ -1,5 +1,9 @@
 # py_rssa
 
-This is a partial Python reimplementation of the `rssa` package. It now
-includes a pure Python Hankel helper and exposes basic ``ssa``,
-``reconstruct``, ``wcor`` and ``wnorm`` capabilities.
+This project provides a lightweight Python port of the `rssa` package.
+Alongside the original one-dimensional routines it now includes:
+
+* ``cssa`` for complex valued series.
+* ``NDSSA``/``ndssa`` supporting arbitrary dimensional data and shaped
+  window masks.
+* Pure Python Hankel helpers and utilities such as ``wcor`` and ``wnorm``.

--- a/py_rssa/py_rssa/__init__.py
+++ b/py_rssa/py_rssa/__init__.py
@@ -4,6 +4,7 @@ from .ssa import (
     SSA,
     PartialSSA,
     WOSSA,
+    cssa,
     ssa,
     pssa,
     wossa,
@@ -19,6 +20,7 @@ from .ssa import (
 )
 
 from .mssa import MSSA, mssa, reconstruct, gapfill as mssa_gapfill, forecast as mssa_forecast
+from .ndssa import NDSSA, ndssa
 from .gapfill import gapfill
 from .ossa import cond, pseudo_inverse, orthogonalize, svd_to_lrsvd, owcor
 from .eossa import eossa
@@ -78,8 +80,11 @@ __all__ = [
     "SSA",
     "PartialSSA",
     "WOSSA",
+    "NDSSA",
+    "cssa",
     "MSSA",
     "ssa",
+    "ndssa",
     "pssa",
     "wossa",
     "orthopoly",

--- a/py_rssa/py_rssa/ndssa.py
+++ b/py_rssa/py_rssa/ndssa.py
@@ -1,0 +1,90 @@
+import numpy as np
+from numpy.linalg import svd
+from numpy.lib.stride_tricks import sliding_window_view
+from .hbhankel import factor_mask_2d, field_weights_2d
+
+class NDSSA:
+    """Basic N-Dimensional SSA with optional shaped window mask."""
+
+    def __init__(self, x, L=None, wmask=None, mask=None, circular=False):
+        x = np.asarray(x)
+        self.is_complex = np.iscomplexobj(x)
+        if mask is None:
+            mask = np.isfinite(x)
+        else:
+            mask = np.asarray(mask, dtype=bool)
+        fill = np.nanmean(x.real if self.is_complex else x, where=mask)
+        x = np.where(mask, x, fill)
+        self.x = x
+
+        self.N = x.shape
+        rank = x.ndim
+        if L is None:
+            L = tuple((n + 1) // 2 for n in self.N)
+        L = tuple(int(l) for l in L)
+        if wmask is None:
+            wmask = np.ones(L, dtype=bool)
+        else:
+            wmask = np.asarray(wmask, dtype=bool)
+            if wmask.shape != L:
+                raise ValueError("wmask shape must match window length")
+        self.L = L
+        self.wmask = wmask
+
+        if isinstance(circular, bool):
+            circular = (circular,) * rank
+        if len(circular) != rank:
+            circular = tuple(circular[i % len(circular)] for i in range(rank))
+        self.circular = tuple(bool(c) for c in circular)
+
+        fmask = factor_mask_2d(mask, wmask, circular=self.circular)
+        self.fmask = fmask
+        self.weights = field_weights_2d(wmask, fmask, circular=self.circular)
+
+        K = tuple(n if c else n - l + 1 for n, l, c in zip(self.N, L, self.circular))
+        self.K = K
+
+        sw = sliding_window_view(self.x, L)
+        sw = sw.reshape(int(np.prod(K)), -1)
+        cols = sw[fmask.ravel()]
+        cols = cols[:, wmask.ravel()]
+        self.X = cols.T
+
+        self.U, s, self.Vt = svd(self.X, full_matrices=False)
+        self.s = s
+
+    def reconstruct(self, indices):
+        U = self.U[:, indices]
+        s = self.s[indices]
+        Vt = self.Vt[indices]
+        Xr = (U * s) @ Vt
+        Ldim = self.wmask.sum()
+        Kidx = np.argwhere(self.fmask.ravel()).ravel()
+        recon = np.zeros(self.N, dtype=self.x.dtype)
+        counts = np.zeros(self.N, dtype=int)
+        Lslices = tuple(slice(0, l) for l in self.L)
+        wmask_idx = np.where(self.wmask)
+        for col_i, k in enumerate(Kidx):
+            idx = []
+            rem = k
+            for n, l, c in zip(reversed(self.N), reversed(self.L), reversed(self.circular)):
+                if c:
+                    pos = rem % n
+                    rem //= n
+                else:
+                    pos = rem % (n - l + 1)
+                    rem //= (n - l + 1)
+                idx.append(pos)
+            idx = tuple(reversed(idx))
+            slices = tuple(slice(i, i + l) for i, l in zip(idx, self.L))
+            patch = np.zeros(self.L, dtype=self.x.dtype)
+            patch[wmask_idx] = Xr[:, col_i]
+            recon[slices][self.wmask] += patch[wmask_idx]
+            counts[slices][self.wmask] += 1
+        result = np.where(counts > 0, recon / counts, np.nan)
+        return result
+
+def ndssa(x, L=None, wmask=None, mask=None, circular=False):
+    return NDSSA(x, L=L, wmask=wmask, mask=mask, circular=circular)
+
+__all__ = ["NDSSA", "ndssa"]

--- a/py_rssa/py_rssa/ssa.py
+++ b/py_rssa/py_rssa/ssa.py
@@ -6,11 +6,12 @@ from numpy.linalg import svd, qr
 class SSA:
     """Simple SSA implementation mirroring ``rssa::ssa`` core features."""
     def __init__(self, x, L=None):
-        raw_x = np.asarray(x, dtype=float)
+        raw_x = np.asarray(x)
+        dtype = complex if np.iscomplexobj(raw_x) else float
         if np.isnan(raw_x).any():
             fill = np.nanmean(raw_x)
             raw_x = np.nan_to_num(raw_x, nan=fill)
-        self.x = raw_x
+        self.x = raw_x.astype(dtype)
         N = self.x.size
         if L is None:
             L = (N + 1) // 2
@@ -32,7 +33,7 @@ class SSA:
         N = self.x.size
         L = self.L
         K = self.K
-        recon = np.zeros(N)
+        recon = np.zeros(N, dtype=self.x.dtype)
         counts = np.zeros(N)
         for i in range(L):
             for j in range(K):
@@ -65,7 +66,7 @@ class SSA:
     def wnorm(self):
         """Weighted norm of the original series."""
         w = hankel_weights(self.L, self.K)
-        return np.sqrt(np.sum(w * self.x ** 2))
+        return np.sqrt(np.sum(w * np.abs(self.x) ** 2))
 
     def contributions(self, indices=None):
         """Return relative contribution of selected eigentriples."""
@@ -285,6 +286,10 @@ def hankel_weights(L, K):
 def wossa(x, L=None, column_oblique=None, row_oblique=None):
     """Convenience function returning :class:`WOSSA`."""
     return WOSSA(x, L=L, column_oblique=column_oblique, row_oblique=row_oblique)
+
+def cssa(x, L=None):
+    """Convenience function for complex SSA."""
+    return SSA(x, L=L)
 
 def wnorm(x, *, L=None, weights=None):
     """Weighted norm of a sequence.

--- a/py_rssa/tests/test_cssa.py
+++ b/py_rssa/tests/test_cssa.py
@@ -1,0 +1,10 @@
+import numpy as np
+from py_rssa import cssa
+
+
+def test_complex_ssa_basic():
+    t = np.arange(10)
+    x = np.exp(1j * t)
+    s = cssa(x, L=5)
+    rec = s.reconstruct([0])
+    assert np.allclose(rec, x)

--- a/py_rssa/tests/test_ndssa.py
+++ b/py_rssa/tests/test_ndssa.py
@@ -1,0 +1,17 @@
+import numpy as np
+from py_rssa import NDSSA, ndssa
+
+
+def test_ndssa_reconstruction_rectangular():
+    x = np.arange(9).reshape(3, 3).astype(float)
+    s = NDSSA(x, L=(2, 2))
+    rec = s.reconstruct([0])
+    assert np.allclose(rec, x)
+
+
+def test_ndssa_shaped_window():
+    x = np.arange(9).reshape(3, 3).astype(float)
+    wmask = np.array([[1, 0], [1, 1]], dtype=bool)
+    s = ndssa(x, L=(2, 2), wmask=wmask)
+    rec = s.reconstruct([0])
+    assert np.allclose(rec, x)


### PR DESCRIPTION
## Summary
- support complex series in SSA via `cssa`
- implement N-D SSA with shaped window masks (`NDSSA`)
- export new helpers and update README
- test NDSSA reconstruction and complex SSA

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68601fcf7aa083308461d67b4fb587a1